### PR TITLE
[bugfix] PASS optional for non-TLS non-SSL SMTP.

### DIFF
--- a/Core/EmailNotification.py
+++ b/Core/EmailNotification.py
@@ -64,7 +64,6 @@ class EmailNotification(object):
 
         try:
             if protocol == 'SSL' or protocol == 'ssl':
-
                 server = SMTP_SSL(str(information['smtp']), port)
                 server.ehlo
                 server.login(addr, pas)
@@ -80,7 +79,8 @@ class EmailNotification(object):
                 return True
             else:
                 server = SMTP(str(information['smtp']), port)
-                server.login(addr, pas)
+                if pas != "":
+                  server.login(addr, pas)
                 server.sendmail(addr, recipients, msg.as_string())
                 print('sending Email....')
                 return True


### PR DESCRIPTION
I suspect password is mandatory for TLS and SSL, and so I've added this single line to stock SMTP that gives folk the option of not having a password, e.g. in the instance at my work place.

The UI permits this already so no worries with additional checks or not there. 
